### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -62,7 +62,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5.3.0 # v5.0.0
+        uses: docker/build-push-action@v6.2.0 # v5.0.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.2.0](https://github.com/docker/build-push-action/releases/tag/v6.2.0)** on 2024-06-26T13:09:11Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
